### PR TITLE
all posts and post detail views are laid out

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -3,20 +3,16 @@ import React from "react"
 import { Route } from "react-router-dom"
 import { PostForm} from "./posts/PostEntry"
 import { CategoryList } from "./categories/category_list"
+import { PostDetails } from "./posts/PostDetails"
+import { PostRoutes } from "./PostRoutes"
 
 export const ApplicationViews = () => {
   return (
     <>
-    <h1 >Welcome to Rare Publishing</h1>
-    <Route exact path = "/categories">
+    <Route exact path ="/categories">
       <CategoryList/>
     </Route>
-    <Route exact path="/posts">
-        <PostList />
-    </Route>
-    <Route exact path="/newPost">
-        <PostForm />
-    </Route>
+    <PostRoutes />
     </>
   )
 }

--- a/src/components/PostRoutes.js
+++ b/src/components/PostRoutes.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react"
+import { Route } from "react-router-dom"
+import { PostsRepository } from "../repositories/PostsRepository"
+import { PostDetails } from "./posts/PostDetails"
+import { PostForm } from "./posts/PostEntry"
+import { PostList } from "./posts/PostList"
+
+export const PostRoutes = () => {
+    const [posts, setPosts] = useState([])
+
+    const syncPosts = () => {
+        PostsRepository.getAll().then(setPosts)
+    }
+
+    useEffect(() => {
+        syncPosts()
+    }, [])
+    
+    return (
+        <>
+            <Route exact path="/posts">
+                <PostList posts={posts} syncPosts={syncPosts} />
+            </Route>
+            <Route exact path="/posts/:postId(\d+)">
+                <PostDetails posts={posts} syncPosts={syncPosts} />
+            </Route>
+            <Route exact path="/newPost">
+                <PostForm posts={posts} syncPosts={syncPosts} />
+            </Route>
+        </>
+    )
+}

--- a/src/components/posts/Post.css
+++ b/src/components/posts/Post.css
@@ -1,0 +1,4 @@
+#titleLink:hover {
+    cursor: pointer;
+    border-bottom: 1px solid black;
+}

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -1,12 +1,12 @@
-import { Link } from "react-router-dom"
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min"
+import "./Post.css"
 
 export const Post = (props) => {
     const history = useHistory()
     return (
         <tbody>
             <tr>
-                <td onClick={() => history.push(`/posts/${props.id}`)}>{props.title}</td>
+                <td id="titleLink" onClick={() => history.push(`/posts/${props.id}`)}>{props.title}</td>
                 <td>{props.user?.firstName} {props.user?.lastName}</td>
                 <td>{props.publicationDate}</td>
                 <td>{props.category}</td>

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -1,24 +1,17 @@
-import { useState } from "react"
+import { Link } from "react-router-dom"
+import { useHistory } from "react-router-dom/cjs/react-router-dom.min"
 
 export const Post = (props) => {
-    const [posts, setPosts] = useState([])
-
+    const history = useHistory()
     return (
-        <div className="card">
-            <header className="card-header">
-                <p className="card-header-title">
-                    {props.title}
-                </p>
-            </header>
-            <div className="card-content">
-                <div className="content">
-                    {props.content}
-                </div>
-            </div>
-            <footer className="card-footer">
-                <a href="#" className="card-footer-item">Edit</a>
-                <a href="#" className="card-footer-item">Delete</a>
-            </footer>
-        </div>
+        <tbody>
+            <tr>
+                <td onClick={() => history.push(`/posts/${props.id}`)}>{props.title}</td>
+                <td>{props.user?.firstName} {props.user?.lastName}</td>
+                <td>{props.publicationDate}</td>
+                <td>{props.category}</td>
+                <td>tags go here</td>
+            </tr>
+        </tbody>
     )
 }

--- a/src/components/posts/PostDetails.css
+++ b/src/components/posts/PostDetails.css
@@ -1,0 +1,10 @@
+.subtitle {
+    text-align: center;
+}
+.author-and-tags {
+    display: flex;
+    justify-content: space-between;
+}
+.post-category {
+    float: right;
+}

--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -1,0 +1,32 @@
+import { useParams } from "react-router-dom"
+import "./PostDetails.css"
+export const PostDetails = ({ posts, syncPosts }) => {
+    const { postId } = useParams()
+
+    const foundPost = posts.find(p => p.id === parseInt(postId))
+
+    return (
+        <div className="post-detail-container">
+            <div className="post-category">category goes here</div>
+            <h2 className="subtitle post-title">{foundPost?.title}</h2>
+            <div className="author-and-tags">
+                <div>Author goes here</div>
+                <button className="button">View comments</button>
+                <div className="tags-container">
+                    {/* Here we can map over all the tags tied to this specific post */}
+                    <div>Tags go here</div>
+                    <div>Tags go here</div>
+                    <div>Tags go here</div>
+                </div>
+            </div>
+            <div>{foundPost?.publication_date}</div>
+            <div className="card">
+                <div className="card-content">
+                    <div className="content">
+                        {foundPost?.content}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -1,35 +1,41 @@
-import { useEffect, useState } from "react"
-import { PostsRepository } from "../../repositories/PostsRepository"
+import { useState } from "react"
 import { Post } from "./Post"
-import {Link} from "react-router-dom"
 
-export const PostList = () => {
-    const [posts, setPosts] = useState([])
+export const PostList = ({ posts, syncPosts }) => {
     const [users, setUsers] = useState([])
     const [categories, setCategories] = useState([])
 
-    const syncPosts = () => {
-        PostsRepository.getAll().then(setPosts)
-    }
-
-    useEffect(() => {
-        syncPosts()
-    }, [])
-
     return (
-        posts.map(post => {
-            // We still need to fetch users and categories from the 
-            const foundUser = users.find(user => user.id === post.userId)
-            const foundCategory = categories.find(category => category.id === post.categoryId)
+        <>
+            <table className="table">
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Date</th>
+                        <th>Category</th>
+                        <th>Tags</th>
+                    </tr>
+                </thead>
+                {
+                    posts.map(post => {
+                        // We still need to fetch users and categories from the server
+                        const foundUser = users.find(user => user.id === post.userId)
+                        const foundCategory = categories.find(category => category.id === post.categoryId)
 
-            return <Post
-            key={post.id}
-            title={post.title}
-            content={post.content}
-            publicationDate={post.publicationDate}
-            user={foundUser}
-            category={foundCategory}
-            />
-        })
+                        return <Post
+                            key={post.id}
+                            id={post.id}
+                            title={post.title}
+                            content={post.content}
+                            publicationDate={post.publicationDate}
+                            user={foundUser}
+                            category={foundCategory}
+                            syncPosts={syncPosts}
+                        />
+                    })
+                }
+            </table>
+        </>
     )
 }


### PR DESCRIPTION
### Issue ticket(s): #23

### New file(s): PostRoutes.js, PostDetails.js, PostDetails.css

### Modified File(s): ApplicationViews.js, Post.js, PostList.js

### Modifications: 
- Refactored ApplicationViews to use PostRoutes as the parent component to handle all of the routes for post views
- The Post component now returns  `<tbody>` element instead of a card element
- The PostList component is now set up to display all posts in a table element
- The PostDetails component will render information about a single post (the one clicked on in the PostList component)

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to al-postDetails
3. Navigate to the list of posts by clicking "Posts" in the navbar
4. Click on the title of a post, and you should be redirected to the PostDetails component for that particular post
