### PR TITLE
User can now view PostList and MyPosts components

### DIFF
--- a/src/components/posts/MyPost.js
+++ b/src/components/posts/MyPost.js
@@ -1,47 +1,13 @@
-import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
-import { getCategories } from "../../repositories/CategoriesRepository"
-import { get_all_users } from "../../repositories/UserRepository"
-import {Post} from "./Post"
+import { Post } from "./Post"
 
-export const MyPostList = ({posts, syncPosts}) => {
-    const [post, setPosts] = useState([])
-    const [categories, setCategories] = useState([])
-    const [users, setUsers] = useState([])
-
-    useEffect((
-        () => {
-            fetch(`http://localhost:8088/posts`)
-                .then(res => res.json())
-                .then((data) => {
-                    setPosts(data)
-                })
-        }
-    ), [])
-    
-
-    const getMyPosts = () => {
-        let myPosts = []
-        const user = parseInt(localStorage.getItem("token"))
-        for (const myPost of post) {
-            if (parseInt(myPost.user_id) === user) {
-                myPosts.push(myPost)
-            }
-        }
-        return myPosts
-    }
-
-    
-    useEffect(() => {
-        get_all_users().then(setUsers)
-        getCategories().then(setCategories)
-    }, [])
+export const MyPostList = ({ posts, syncPosts }) => {
 
     return (
         <>
-                <div>
-                    <center> <Link to="/newPost" className="navbar-item">New Post</Link></center>
-                </div>
+            <div>
+                <center> <Link to="/newPost" className="navbar-item">New Post</Link></center>
+            </div>
             <table className="table">
                 <thead>
                     <tr>
@@ -50,31 +16,29 @@ export const MyPostList = ({posts, syncPosts}) => {
                         <th>Date</th>
                         <th>Category</th>
                         <th>Tags</th>
-                      
+
                     </tr>
                 </thead>
                 {
-                    getMyPosts().map(post => {
-                        const foundUser = users.find(user => user.id === post.user_id)
-                        const foundCategory = categories.find(category => category.id === post.category_id)
-                        
+                    posts.map(post => {
                         return (
-                            <>
-                            <Post
-                                key={post.id} 
-                                postId={post.id} 
-                                title={post.title}
-                                content={post.content}
-                                publicationDate={post.publication_date}
-                                user={foundUser}
-                                category={foundCategory}
-                                syncPosts={syncPosts}
-                                
-                                />
-                     
-                            </>
-                     ) })
-                    }
+                            post.is_owner
+                                ? 
+                                    <Post
+                                        key={post.id}
+                                        postId={post.id}
+                                        title={post.title}
+                                        content={post.content}
+                                        publicationDate={post.publication_date}
+                                        user={post.user.user}
+                                        category={post.category}
+                                        syncPosts={syncPosts}
+                                        tags={post.tags}
+                                    />
+                                : ""
+                        )
+                    })
+                }
             </table>
         </>
     )

--- a/src/components/posts/MyPost.js
+++ b/src/components/posts/MyPost.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 import { getCategories } from "../../repositories/CategoriesRepository"
-import { PostTagsRepository } from "../../repositories/PostTagsRepository"
 import { get_all_users } from "../../repositories/UserRepository"
 import {Post} from "./Post"
 
@@ -9,7 +8,6 @@ export const MyPostList = ({posts, syncPosts}) => {
     const [post, setPosts] = useState([])
     const [categories, setCategories] = useState([])
     const [users, setUsers] = useState([])
-    const [postTags, setPostTags] = useState([])
 
     useEffect((
         () => {
@@ -37,7 +35,6 @@ export const MyPostList = ({posts, syncPosts}) => {
     useEffect(() => {
         get_all_users().then(setUsers)
         getCategories().then(setCategories)
-        PostTagsRepository.getAll().then(setPostTags)
     }, [])
 
     return (

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -1,42 +1,17 @@
-import { useEffect, useState } from "react"
-import { Link } from "react-router-dom"
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min"
-import { PostTagsRepository } from "../../repositories/PostTagsRepository"
-import { getTags } from "../../repositories/TagsRepository"
 import "./Post.css"
 
 export const Post = (props) => {
     const history = useHistory()
-    // const [postTags, setPostTags] = useState([])
-    // const [tags, setTags] = useState([])
-
-    // useEffect(() => {
-    //     PostTagsRepository.getAll().then(setPostTags)
-    //     getTags().then(setTags)
-    // }, [])
-
-    // const getTagsForCurrentPost = () => {
-    //     let arr = []
-    //     for (const tag of tags) {
-    //         for (const postTag of postTags) {
-    //             if (tag.id === postTag.tag_id && props.postId === postTag.post_id) {
-    //                 arr.push(tag)
-    //             }
-    //         }
-    //     }
-    //     return arr
-    // }
 
     const delete_post = (id) => {
-        fetch(`http://localhost:8088/posts/${id}`, { method: 'DELETE' })
+        fetch(`http://localhost:8000/posts/${id}`, { method: 'DELETE' })
             // .then(res => res.json())
             .then(() => {
                 history.push("/posts")
             })
             .then(() => props.syncPosts())
     }
-
-    // const tagsForCurrentPost = getTagsForCurrentPost()
 
     return (
         <>

--- a/src/components/posts/PostEdit.js
+++ b/src/components/posts/PostEdit.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react"
 import { getCategories } from "../../repositories/CategoriesRepository"
-import { PostTagsRepository } from "../../repositories/PostTagsRepository"
 import { useHistory, useParams } from "react-router-dom/cjs/react-router-dom.min"
 import { getSinglePost } from "../../repositories/PostsRepository"
 import { getTags } from "../../repositories/TagsRepository"
@@ -10,7 +9,6 @@ export const EditPost = ({ posts, syncPosts }) => {
 
     const [categories, setCategories] = useState([])
     const [tags, setTags] = useState([])
-    const [postTags, setPostTags] = useState([])
     const { postId } = useParams()
     const [post, setPost] = useState({})
     const [newPost, setNewPost] = useState({
@@ -49,7 +47,6 @@ export const EditPost = ({ posts, syncPosts }) => {
     useEffect(() => {
         getTags().then(setTags)
         getCategories().then(setCategories)
-        // PostTagsRepository.getAll().then(setPostTags)
     }, [])
 
 

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react"
 import { Post } from "./Post"
 import { Link } from "react-router-dom"
-import { PostsRepository } from "../../repositories/PostsRepository"
 import { get_all_users } from "../../repositories/UserRepository"
 import { getCategories } from "../../repositories/CategoriesRepository"
-import { PostTagsRepository } from "../../repositories/PostTagsRepository"
 
 
 export const PostList = ({ posts, syncPosts }) => {
@@ -51,7 +49,7 @@ export const PostList = ({ posts, syncPosts }) => {
                     <option key="author--0" value={0}>Author</option>
                     {users.map((user) => (
                         <option key={user.id} value={user.id}>
-                            {user.first_name} {user.last_name}
+                            {user.user.first_name} {user.user.last_name}
                         </option>
                     ))}
                 </select>
@@ -69,33 +67,30 @@ export const PostList = ({ posts, syncPosts }) => {
                 {
                     posts.map(
                         (post) => {
-                            const foundUser = users.find(user => user.id === post.user_id)
-                            const foundCategory = categories.find(category => category.id === post.category_id)
-
                             if (categoryFilter !== 0 && authorFilter !== 0) {
-                                if (post.category_id === categoryFilter && post.user_id === authorFilter) {
+                                if (post.category.id === categoryFilter && post.user.id === authorFilter) {
                                     return <Post
                                         key={post.id}
                                         postId={post.id}
                                         title={post.title}
                                         content={post.content}
                                         publicationDate={post.publication_date}
-                                        user={foundUser}
-                                        category={foundCategory}
+                                        user={post.user.user}
+                                        category={post.category}
                                         syncPosts={syncPosts}
                                         tags={post.tags}
                                     />
                                 }
                             } else {
-                                if (post.category_id === categoryFilter || post.user_id === authorFilter) {
+                                if (post.category.id === categoryFilter || post.user.id === authorFilter) {
                                     return <Post
                                         key={post.id}
                                         postId={post.id}
                                         title={post.title}
                                         content={post.content}
                                         publicationDate={post.publication_date}
-                                        user={foundUser}
-                                        category={foundCategory}
+                                        user={post.user.user}
+                                        category={post.category}
                                         syncPosts={syncPosts}
                                         tags={post.tags}
 
@@ -107,8 +102,8 @@ export const PostList = ({ posts, syncPosts }) => {
                                         title={post.title}
                                         content={post.content}
                                         publicationDate={post.publication_date}
-                                        user={foundUser}
-                                        category={foundCategory}
+                                        user={post.user.user}
+                                        category={post.category}
                                         syncPosts={syncPosts}
                                         tags={post.tags}
 

--- a/src/components/tags/tag_list.js
+++ b/src/components/tags/tag_list.js
@@ -17,17 +17,17 @@ export const TagList = () => {
 
     return (
         <>
-        <div className="is-flex is-align-content-space-evenly">
-            <div className="section">
-            {
-                tags.map(tag => {
-                   return <p className="subtitle is-size-5-desktop" key={tag.id}>{tag.label}</p>
-                })
-            }
-            </div>
-            <div className="section" >
-            <TagForm syncTags={syncTags}/>
-            </div>
+            <div className="is-flex is-align-content-space-evenly">
+                <div className="section">
+                    {
+                        tags.map(tag => {
+                            return <p className="subtitle is-size-5-desktop" key={tag.id}>{tag.label}</p>
+                        })
+                    }
+                </div>
+                <div className="section" >
+                    <TagForm syncTags={syncTags} />
+                </div>
             </div>
         </>
     )

--- a/src/repositories/PostTagsRepository.js
+++ b/src/repositories/PostTagsRepository.js
@@ -1,8 +1,0 @@
-import { Settings } from "../components/utils/Settings"
-
-export const PostTagsRepository = {
-    async getAll() {
-        const res = await fetch(`${Settings.remoteURL}/posttags`)
-        return await res.json()
-    }
-}


### PR DESCRIPTION
### Modifications:
- Got rid of all the PostTagsRepository module and all the realted fetch calls for post tags since we are getting them all on each individual post object now
### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to al-postTags
3. Log in to the client and navigate to both the PostList and MyPosts components
4. In MyPosts you should only see the currently logged in user's posts
5. Filter dropdowns should work properly in the PostList component